### PR TITLE
fix share all axes

### DIFF
--- a/interplot/plot.py
+++ b/interplot/plot.py
@@ -693,6 +693,10 @@ class Plot(NotebookInteraction):
             shared_xaxes = "columns"
         if shared_yaxes == "cols":
             shared_yaxes = "columns"
+        if shared_xaxes is True:
+            shared_xaxes = "all"
+        if shared_yaxes is True:
+            shared_yaxes = "all"
 
         self.interactive = pick_non_none(
             interactive,


### PR DESCRIPTION
translate `True` to `"all"` for the keyword arguments `shared_xaxes, shared_yaxes` in `ip.Plot`, so that axes are shared along x and y in 2D grids of plots